### PR TITLE
Refactor for lesions analysis - Connectomics

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -54,6 +54,7 @@ DESCRIPTION
                                                 │   │── *dwi.bvec (optional)
                                                 │   │── *peaks.nii.gz (optional)
                                                 │   │── *fodf.nii.gz (optional)
+                                                │   │── *lesion_mask.nii.gz (optional, diff space)
                                                 |   └── metrics (optional)
                                                 |       └── METRIC_NAME.nii.gz
                                                 └── S2

--- a/USAGE
+++ b/USAGE
@@ -35,6 +35,10 @@ Which is (NBR_PARCEL) * (NBR_PARCEL-1) / 2. Running connectoflow with a freesurf
 parcellation is A LOT faster than with Brainnetome, which is A LOT faster than
 with Glasser, make sure to test & optimize calls before launching on clusters.
 
+If providing a lesion mask, the nifti should be a uint8 binary image representing
+the voxel that are considered lesions. These lesions should have been taken into account
+when generating the tractogram (to allow tractography within the lesions).
+
 USAGE
 
 nextflow run main.nf [OPTIONAL_ARGUMENTS] --input --template --labels_list
@@ -88,8 +92,9 @@ OPTIONAL ARGUMENTS (current value)
     --length_weighting                          If set, will weigh the AFD values according to segment lengths for afd/rd ($length_weighting)
     --sh_basis                                  Spherical harmonics basis used for the SH coefficients  ($sh_basis)
 
+    --min_lesion_vol                            To be consider 'a lesion' for the pipeline, a lesion must be at least ($min_lesion_vol) mm3.
     --use_similarity_metric                     Compute the average shape distance for each connection ($use_similarity_metric)
-    --nbr_subjects_for_avg_connections                             The average shape is computed from a random subset of subjects ($nbr_subjects_for_avg_connections)
+    --nbr_subjects_for_avg_connections          The average shape is computed from a random subset of subjects ($nbr_subjects_for_avg_connections)
 
     --processes_register                        Number of processes for registration task ($processes_register)
     --processes_commit                          Number of processes for COMMIT task ($processes_commit)

--- a/USAGE
+++ b/USAGE
@@ -105,6 +105,15 @@ OPTIONAL ARGUMENTS (current value)
     --processes                                 The number of parallel processes to launch ($cpu_count).
                                                 Only affects the local scheduler.
 
+AVAILABLE PROFILES (using -profile option (e.g. -profile use_cuda,fully_reproducible))
+
+macos                                       When this profile is used, TractoFlow will modify a parameter (scratch) for MacOS users.
+
+large_dataset                               Double the allocate RAM for Decompose and COMMIT (6GB -> 12GB)
+
+fully_reproducible                          When this profile is used, all the parameters will be set to have 100% reproducible results.
+   
+
 NOTES
 
 To set the number of parallel processes to launch, please use:

--- a/USAGE
+++ b/USAGE
@@ -7,6 +7,9 @@ or civet) and the affine and nonlinear transformation must bring these images
 to diffusion space. We recommand running the command scil_verify_space_attributes_compatibility
 with the t1 and labels to ensure they are indeed in the same space.
 
+The atlas must be stripped of the WM and CSF labels and only keep the cortical and
+subcortical labels (brainstem/cerebelum optional).
+
 The rest of the input (tracking, dwi, peaks, fodf and all metrics)
 must be in diffusion space with compatible headers. We recommand running the command 
 scil_verify_space_attributes_compatibility with the all the files mentioned above
@@ -38,6 +41,7 @@ with Glasser, make sure to test & optimize calls before launching on clusters.
 If providing a lesion mask, the nifti should be a uint8 binary image representing
 the voxel that are considered lesions. These lesions should have been taken into account
 when generating the tractogram (to allow tractography within the lesions).
+The lesion mask MUST BE in the same space as the DWI with the same header.
 
 USAGE
 
@@ -95,7 +99,7 @@ OPTIONAL ARGUMENTS (current value)
 
     --min_lesion_vol                            To be consider 'a lesion' for the pipeline, a lesion must be at least ($min_lesion_vol) mm3.
     --use_similarity_metric                     Compute the average shape distance for each connection ($use_similarity_metric)
-    --nbr_subjects_for_avg_connections          The average shape is computed from a random subset of subjects ($nbr_subjects_for_avg_connections)
+    --nbr_subjects_for_avg_connections          The average shape is computed from a random subset of subjects, must be equal or lower than the total number of subjects ($nbr_subjects_for_avg_connections)
 
     --processes_register                        Number of processes for registration task ($processes_register)
     --processes_commit                          Number of processes for COMMIT task ($processes_commit)

--- a/main.nf
+++ b/main.nf
@@ -125,8 +125,13 @@ Channel
     .map{[it.parent.name, it]}
     .into{fodf_for_afd_rd;fodf_for_count}
 
+Channel
+    .fromFilePairs("$params.input/**/lesion_mask.nii.gz",
+        size: -1) { it.parent.name }
+    .set{lesion_for_lesion_load}
+
 Channel.fromPath(file(params.template))
-    .into{template_for_registration;template_for_transformation_data;template_for_transformation_metrics}
+    .into{template_for_registration;template_for_transformation_data;template_for_transformation_metrics;template_for_transformation_lesions}
 
 Channel.fromPath(file(params.labels_list))
     .into{labels_list_for_compute;labels_list_for_visualize}
@@ -215,7 +220,7 @@ process Transform_T1_Labels {
 
 ori_anat
     .concat(transformed_anat)
-    .into{anat_for_registration;anat_for_concatenate;anat_for_metrics}
+    .into{anat_for_registration;anat_for_concatenate;anat_for_metrics;anat_for_lesions}
 ori_labels
     .concat(transformed_labels)
     .into{labels_for_transformation;labels_for_decompose}
@@ -390,7 +395,7 @@ process Register_Anat {
     set sid, file(native_anat), file(template) from anats_for_registration
 
     output:
-    set sid, "${sid}__output0GenericAffine.mat", "${sid}__output1Warp.nii.gz", "${sid}__output1InverseWarp.nii.gz"  into transformation_for_data, transformation_for_metrics
+    set sid, "${sid}__output0GenericAffine.mat", "${sid}__output1Warp.nii.gz", "${sid}__output1InverseWarp.nii.gz"  into transformation_for_data, transformation_for_metrics, transformation_for_lesions
     file "${sid}__outputWarped.nii.gz"
     script:
     """
@@ -418,6 +423,27 @@ process Transform_Metrics {
     script:
     """
     antsApplyTransforms -d 3 -i $metric -r $template -t $warp $transfo -o ${metric.getSimpleName()}_mni.nii.gz
+    """
+}
+
+lesion_for_lesion_load
+    .join(transformation_for_lesions)
+    .combine(template_for_transformation_lesions)
+    .set{lesions_transformation_for_data}
+
+process Transform_Lesions {
+    cpus 1
+
+    input:
+    set sid, file(lesion), file(transfo), file(warp), file(inverse_warp), file(template) from lesions_transformation_for_data
+
+    output:
+    set sid, "lesion_mask_mni.nii.gz" into lesions_for_compute
+
+    script:
+    """
+    antsApplyTransforms -d 3 -i $lesion -r $template -t $warp $transfo -o ${lesion.getSimpleName()}_mni.nii.gz -n NearestNeighbor
+    scil_image_math.py convert lesion_mask_mni.nii.gz lesion_mask_mni.nii.gz --data_type uint8 -f
     """
 }
 
@@ -474,6 +500,7 @@ process Average_Connections {
 }
 
 metrics_for_compute
+    .concat(lesions_for_compute)
     .groupTuple()
     .set{all_metrics_for_compute}
 
@@ -511,14 +538,23 @@ process Compute_Connectivity_with_similiarity {
         base_name=\$(basename \${metric/_mni/})
         base_name=\${base_name/_warped/}
         base_name=\${base_name/"${sid}__"/}
-        metrics_args="\${metrics_args} --metrics \${metric} \$(basename \$base_name .nii.gz).npy"
+        if [[ \$metric == lesion_mask_mni.nii.gz ]]; then
+            lesion_args=--lesion_load \$metric ./
+        else
+            metrics_args="\${metrics_args} --metrics \${metric} \$(basename \$base_name .nii.gz).npy"
+        fi
     done
 
-    scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list --volume vol.npy --streamline_count sc.npy \
-        --length len.npy --similarity $avg_edges sim.npy \$metrics_args --density_weighting --no_self_connection \
-        --include_dps ./ --processes $params.processes_connectivity
-    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy --parcel_volume $labels $labels_list
-    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy --parcel_volume $labels $labels_list
+    scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list \
+        --volume vol.npy --streamline_count sc.npy \
+        --length len.npy --similarity $avg_edges sim.npy \$metrics_args \ 
+        --density_weighting --no_self_connection \
+        --include_dps ./ \$lesion_args \
+        --processes $params.processes_connectivity
+    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy \
+        --parcel_volume $labels $labels_list
+    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy \
+        --parcel_volume $labels $labels_list
     """
 }
 
@@ -540,14 +576,22 @@ process Compute_Connectivity_without_similiarity {
         base_name=\$(basename \${metric/_mni/})
         base_name=\${base_name/_warped/}
         base_name=\${base_name/"${sid}__"/}
-        metrics_args="\${metrics_args} --metrics \${metric} \$(basename \$base_name .nii.gz).npy"
+        if [[ \$metric == lesion_mask_mni.nii.gz ]]; then
+            lesion_args="--lesion_load \$metric ./"
+        else
+            metrics_args="\${metrics_args} --metrics \${metric} \$(basename \$base_name .nii.gz).npy"
+        fi
     done
 
-    scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list --volume vol.npy --streamline_count sc.npy \
-        --length len.npy \$metrics_args --density_weighting --no_self_connection --include_dps ./ \
+    scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list \
+        --volume vol.npy --streamline_count sc.npy \
+        --length len.npy \$metrics_args --density_weighting \
+        --no_self_connection --include_dps ./ \$lesion_args \
         --processes $params.processes_connectivity
-    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy --parcel_volume $labels $labels_list
-    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy --parcel_volume $labels $labels_list
+    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy \
+        --parcel_volume $labels $labels_list
+    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy \
+        --parcel_volume $labels $labels_list
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -23,6 +23,7 @@ if(params.help) {
                 "length_weighting":"$params.length_weighting",
                 "sh_basis":"$params.sh_basis",
                 "run_afd_rd":"$params.run_afd_rd",
+                "min_lesion_vol":"$params.min_lesion_vol",
                 "use_similarity_metric":"$params.use_similarity_metric",
                 "nbr_subjects_for_avg_connections":"$params.nbr_subjects_for_avg_connections",
                 "processes_register":"$params.processes_register",
@@ -82,7 +83,9 @@ log.info "Outliers removal threshold: $params.outlier_threshold"
 log.info "Run AFD & RD: $params.run_afd_rd"
 log.info "Length weighting: $params.length_weighting"
 log.info "SH basis: $params.sh_basis"
+log.info "Minimum lesion volume: $params.min_lesion_vol"
 log.info "Use similarity metric: $params.use_similarity_metric"
+log.info "Average from N subjects: $params.nbr_subjects_for_avg_connections"
 log.info ""
 
 log.info "Number of processes per tasks"
@@ -550,7 +553,7 @@ process Compute_Connectivity_with_similiarity {
         --volume vol.npy --streamline_count sc.npy \
         --length len.npy --similarity $avg_edges sim.npy \$metrics_args \
         --density_weighting --no_self_connection \
-        --include_dps ./ \$lesion_args \
+        --include_dps ./ \$lesion_args --min_lesion_vol $params.min_lesion_vol \
         --processes $params.processes_connectivity
     scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy \
         --parcel_volume $labels $labels_list

--- a/main.nf
+++ b/main.nf
@@ -534,6 +534,7 @@ process Compute_Connectivity_with_similiarity {
     String metrics_list = metrics.join(", ").replace(',', '')
     """
     metrics_args=""
+    lesion_args=""
     for metric in $metrics_list; do
         base_name=\$(basename \${metric/_mni/})
         base_name=\${base_name/_warped/}
@@ -572,6 +573,7 @@ process Compute_Connectivity_without_similiarity {
     String metrics_list = metrics.join(", ").replace(',', '')
     """
     metrics_args=""
+    lesion_args=""
     for metric in $metrics_list; do
         base_name=\$(basename \${metric/_mni/})
         base_name=\${base_name/_warped/}

--- a/main.nf
+++ b/main.nf
@@ -160,13 +160,18 @@ in_dwi_data = Channel
         tuple(sid, bval, bvec, dwi, peaks)]}
     .separate(3)
 
-subjects_for_count.count().into{ number_subj_for_null_check; number_subj_for_compare_dwi; number_subj_for_compare_fodf}
+subjects_for_count.count().into{ number_subj_for_null_check; number_subj_for_compare_dwi; number_subj_for_compare_fodf; number_subj_for_compare_similarity}
 dwi_for_count.count().into{ dwi_for_null_check; dwi_for_compare }
 fodf_for_count.count().into{ fodf_for_null_check; fodf_for_compare }
 
 number_subj_for_null_check
 .subscribe{a -> if (a == 0)
     error "Error ~ No subjects found. Please check the naming convention, your --input path."}
+
+number_subj_for_compare_similarity
+.subscribe{a -> if (a < params.nbr_subjects_for_avg_connections && params.use_similarity_metric)
+    error "Error --nbr_subjects_for_avg_connections is higher than the number of subjects. Please modify it or use --he number of subjects. Please modify it or use --use_similarity_metric"}
+
 
 run_commit = params.run_commit
 dwi_for_null_check

--- a/main.nf
+++ b/main.nf
@@ -539,7 +539,7 @@ process Compute_Connectivity_with_similiarity {
         base_name=\${base_name/_warped/}
         base_name=\${base_name/"${sid}__"/}
         if [[ \$metric == lesion_mask_mni.nii.gz ]]; then
-            lesion_args=--lesion_load \$metric ./
+            lesion_args="--lesion_load \$metric ./"
         else
             metrics_args="\${metrics_args} --metrics \${metric} \$(basename \$base_name .nii.gz).npy"
         fi
@@ -547,7 +547,7 @@ process Compute_Connectivity_with_similiarity {
 
     scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list \
         --volume vol.npy --streamline_count sc.npy \
-        --length len.npy --similarity $avg_edges sim.npy \$metrics_args \ 
+        --length len.npy --similarity $avg_edges sim.npy \$metrics_args \
         --density_weighting --no_self_connection \
         --include_dps ./ \$lesion_args \
         --processes $params.processes_connectivity

--- a/main.nf
+++ b/main.nf
@@ -564,25 +564,18 @@ process Compute_Connectivity_with_similiarity {
         fi
     done
 
-<<<<<<< HEAD
     scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list \
         --volume vol.npy --streamline_count sc.npy \
         --length len.npy --similarity $avg_edges sim.npy \$metrics_args \
         --density_weighting --no_self_connection \
         --include_dps ./ \$lesion_args --min_lesion_vol $params.min_lesion_vol \
         --processes $params.processes_connectivity
+
+    rm rd_fixel.npy
     scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy \
         --parcel_volume $labels $labels_list
     scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy \
         --parcel_volume $labels $labels_list
-=======
-    scil_compute_connectivity.py $h5 $labels --force_labels_list $labels_list --volume vol.npy --streamline_count sc.npy \
-        --length len.npy --similarity $avg_edges sim.npy \$metrics_args --density_weighting --no_self_connection \
-        --include_dps ./ --processes $params.processes_connectivity
-    rm rd_fixel.npy
-    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy --parcel_volume $labels $labels_list
-    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy --parcel_volume $labels $labels_list
->>>>>>> d8c0515607af6ba65b2b8ca522eb197512b77d37
     """
 }
 
@@ -617,16 +610,12 @@ process Compute_Connectivity_without_similiarity {
         --length len.npy \$metrics_args --density_weighting \
         --no_self_connection --include_dps ./ \$lesion_args \
         --processes $params.processes_connectivity
-<<<<<<< HEAD
+
+    rm rd_fixel.npy
     scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy \
         --parcel_volume $labels $labels_list
     scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy \
         --parcel_volume $labels $labels_list
-=======
-    rm rd_fixel.npy
-    scil_normalize_connectivity.py sc.npy sc_edge_normalized.npy --parcel_volume $labels $labels_list
-    scil_normalize_connectivity.py vol.npy sc_vol_normalized.npy --parcel_volume $labels $labels_list
->>>>>>> d8c0515607af6ba65b2b8ca522eb197512b77d37
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -126,7 +126,7 @@ Channel
     .into{fodf_for_afd_rd;fodf_for_count}
 
 Channel
-    .fromFilePairs("$params.input/**/lesion_mask.nii.gz",
+    .fromFilePairs("$params.input/**/*lesion_mask.nii.gz",
         size: -1) { it.parent.name }
     .set{lesion_for_lesion_load}
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,7 @@ params {
         length_weighting=false
         sh_basis="descoteaux07"
 
+    min_lesion_vol=7
     use_similarity_metric=true
     nbr_subjects_for_avg_connections=50
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,7 @@ params {
         processes_avg_similarity=8
         processes_connectivity=4
         params.decompose_memory_limit='6 GB'
-        params.commit_memory_limit='3 GB'
+        params.commit_memory_limit='6 GB'
 
     //**Process control**//
         processes = false
@@ -82,6 +82,7 @@ singularity.autoMounts = true
 profiles {
     large_dataset {
         params.decompose_memory_limit='12 GB'
+        params.commit_memory_limit='12 GB'
     }
 
     fully_reproducible {


### PR DESCRIPTION
Similarly to tractometry for lesiosn, this give access to 3 news matrices for lesions. If the users provided a lesion mask, access to
- lesion_mask_mni_vol (total volume)
- lesion_mask_mni_count (lesion_count)
- lesion_mask_mni_sc (nbr of streamlines going throught the lesions)

To keep it simple, they are computed in scil_compute_connectivity.py and considered like all the other matrices.
At the moment, the lesions must be provided already in diffusion space. This is due to the fact that lesions can come from Flair, T1, T2, etc. and it is much more simple to request to move it to Diff space. This is compatible with the tractometry-flow, which also required lesions in the same space as metrics/bundles which is Diff space too.

PS: lesion_mask_mni_sc is like a disconnectome, the sc.npy is the full connectivity matrix and this one is the results after removing lesions. The --lesion_load make the compute_connectivity even slower, this is due to simple 0.1sec operation being done Nx(N-1)/2 time, which can add up to 20 minutes even for a simple Freesurfer.
If you activate EVERYTHING (commit, similarity, AFD, a bunch of metrics, lesions, with Brainnetome (246 regions) this single step for a single subject is like 2h+

This is an example of lesions count matrix
![image](https://user-images.githubusercontent.com/10820351/109698387-f7cfeb80-7b54-11eb-97ef-bac4d9aad838.png)
