### PR TITLE
Remove kernel computation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -157,7 +157,7 @@ in_dwi_data = Channel
     .map{sid, bval, bvec, dwi, peaks -> 
         [tuple(sid, dwi),
         tuple(sid, bval, bvec, dwi, peaks)]}
-    .separate(3)
+    .separate(2)
 
 subjects_for_count.count().into{ number_subj_for_null_check; number_subj_for_compare_dwi; number_subj_for_compare_fodf; number_subj_for_compare_similarity}
 dwi_for_count.count().into{ dwi_for_null_check; dwi_for_compare }
@@ -235,8 +235,7 @@ ori_labels
     .concat(transformed_labels)
     .into{labels_for_transformation;labels_for_decompose}
 
-in_tracking
-    .into{tracking_for_decompose}
+in_tracking.set{tracking_for_decompose}
 
 tracking_for_decompose
     .join(labels_for_decompose)

--- a/main.nf
+++ b/main.nf
@@ -153,10 +153,9 @@ in_dwi_data = Channel
                     maxDepth:1,
                     flat: true) {it.parent.name}
 
-(dwi_for_count, data_for_kernels, data_for_commit) = in_dwi_data
+(dwi_for_count, data_for_commit) = in_dwi_data
     .map{sid, bval, bvec, dwi, peaks -> 
         [tuple(sid, dwi),
-        tuple(sid, bval, bvec, dwi, peaks),
         tuple(sid, bval, bvec, dwi, peaks)]}
     .separate(3)
 
@@ -237,7 +236,7 @@ ori_labels
     .into{labels_for_transformation;labels_for_decompose}
 
 in_tracking
-    .into{tracking_for_decompose;tracking_for_kernel}
+    .into{tracking_for_decompose}
 
 tracking_for_decompose
     .join(labels_for_decompose)
@@ -284,60 +283,16 @@ process Decompose_Connectivity {
     """
 }
 
-data_for_kernels
-    .join(tracking_for_kernel)
-    .first()
-    .set{data_tracking_for_kernel}
-
-process Compute_Kernel {
-    cpus 1
-    memory params.decompose_memory_limit
-    publishDir = "${params.output_dir}/Compute_Kernel"
-
-    input:
-    set sid, file(bval), file(bvec), file(dwi), file(peaks), file(trackings) from data_tracking_for_kernel
-
-    output:
-    file("kernels/") into kernel_for_commit
-
-    when:
-    run_commit
-
-    script:
-    ball_stick_arg = ""
-    perp_diff_arg = ""
-    if (params.ball_stick || params.use_commit2) {
-        ball_stick_arg="--ball_stick"
-    }
-    else {
-        perp_diff_arg="--perp_diff $params.perp_diff"
-    }
-    """
-    if [ `echo $trackings | wc -w` -gt 1 ]; then
-        scil_streamlines_math.py lazy_concatenate $trackings tracking_concat.trk
-    else
-        mv $trackings tracking_concat.trk
-    fi
-    scil_remove_invalid_streamlines.py tracking_concat.trk tracking_concat_ic.trk --remove_single --remove_overlapping
-
-    scil_run_commit.py tracking_concat_ic.trk $dwi $bval $bvec "${sid}__results_bzs/" --in_peaks $peaks \
-        --processes 1 --b_thr $params.b_thr --nbr_dir $params.nbr_dir $ball_stick_arg \
-        --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff \
-        --save_kernels kernels/ --compute_only
-    """
-}
-
 data_for_commit
     .join(h5_for_commit)
-    .combine(kernel_for_commit)
-    .set{data_tracking_kernel_for_commit}
+    .set{data_tracking_for_commit}
 
 process Run_COMMIT {
     cpus params.processes_commit
     memory params.commit_memory_limit
 
     input:
-    set sid, file(bval), file(bvec), file(dwi), file(peaks), file(h5), file(kernels) from data_tracking_kernel_for_commit
+    set sid, file(bval), file(bvec), file(dwi), file(peaks), file(h5) from data_tracking_for_commit
 
     output:
     set sid, "${sid}__results_bzs/"
@@ -359,8 +314,7 @@ process Run_COMMIT {
     """
     scil_run_commit.py $h5 $dwi $bval $bvec "${sid}__results_bzs/" --ball_stick --commit2 --in_peaks $peaks \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir \
-        --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff \
-        --load_kernel $kernels
+        --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff
     mv "${sid}__results_bzs/commit_2/decompose_commit.h5" ./"${sid}__decompose_commit.h5"
     """
     }
@@ -368,8 +322,7 @@ process Run_COMMIT {
     """
     scil_run_commit.py $h5 $dwi $bval $bvec "${sid}__results_bzs/" --in_peaks $peaks \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir $ball_stick_arg \
-        --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff \
-        --load_kernel $kernels
+        --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff
     mv "${sid}__results_bzs/commit_1/decompose_commit.h5" ./"${sid}__decompose_commit.h5"
     """
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,8 +26,8 @@ params {
         nbr_dir=500
         ball_stick=true
         para_diff="1.7E-3"
-        perp_diff="0.85E-3 0.51E-3"
-        iso_diff="1.7E-3"
+        perp_diff="0.51E-3"
+        iso_diff="2.0E-3"
 
     // **Decompose options**//
         no_pruning=false


### PR DESCRIPTION
Right now Connectoflow use the kernel of a random subject to prepare COMMIT's kernel. This force the input to be from identical acquisition.

This does not save much time and is a burden for processing large dataset from different sources.
This will impact commit weigth of any previously computed data

Swtich COMMIT parameters to the safe default to scilpy